### PR TITLE
Fix Batch script.

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,4 +1,5 @@
 @echo off
+setlocal enabledelayedexpansion
 
 if not exist build_cache\ (
     echo \"build_cache\" folder not found, it will be created.
@@ -11,18 +12,22 @@ if not exist out\ (
 
 echo Compressing all puyo compressed data in art/art...
 for /r "art\art" %%f in (*.puyo) do (
-    tools\windows\puyomdtool.exe ifnewer compress "%%f" "build_cache\%%f"
+    set "p=%%f"
+    tools\windows\puyomdtool.exe ifnewer compress "%%f" "build_cache\!p:%~dp0=!"
 )
 
 echo Converting all background mappings to their correct formats...
 for /r "art\bg_mappings" %%f in (*.bgbyte) do (
-    tools\windows\puyomdtool.exe ifnewer convertwordin 0 "%%f" "build_cache\%%f"
+    set "p=%%f"
+    tools\windows\puyomdtool.exe ifnewer convertwordin 0 "%%f" "build_cache\!p:%~dp0=!"
 )
 for /r "art\bg_mappings" %%f in (*.bgpalm) do (
-    tools\windows\puyomdtool.exe ifnewer convertwordin 0 "%%f" "build_cache\%%f"
+    set "p=%%f"
+    tools\windows\puyomdtool.exe ifnewer convertwordin 0 "%%f" "build_cache\!p:%~dp0=!"
 )
 for /r "art\bg_mappings" %%f in (*.bgword) do (
-    tools\windows\puyomdtool.exe ifnewer convertwordin 0 "%%f" "build_cache\%%f"
+    set "p=%%f"
+    tools\windows\puyomdtool.exe ifnewer convertwordin 0 "%%f" "build_cache\!p:%~dp0=!"
 )
 
 


### PR DESCRIPTION
Relative paths are needed, or else the tool will receive nonsensical paths like 'build_cache\C:\git\puyo\art\art\tiles.puyo'.

Granted, I don't know a lick of Batch, so this is the best I could do.